### PR TITLE
add compressed terminal output

### DIFF
--- a/qrencode/bits_test.go
+++ b/qrencode/bits_test.go
@@ -1,0 +1,27 @@
+package qrencode
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+)
+
+func TestTerminalOutput(t *testing.T) {
+	//gen random string
+	var b = make([]byte, 100)
+	_, err := rand.Read(b)
+	if err != nil {
+		t.Fatalf("rand.Read err: %v", err)
+	}
+	s := fmt.Sprintf("%x", b)
+
+	grid, err := Encode(s, ECLevelL)
+	if err != nil {
+		t.Fatalf("Encode err: %v", err)
+	}
+
+	//compare two qrcode size in terminal
+	grid.TerminalOutput(os.Stdout)
+	grid.TerminalOutputCompress(os.Stdout)
+}


### PR DESCRIPTION
I added a compressed terminal output method, it print a smaller QRCode on terminal with nearly 75% compression rate.